### PR TITLE
Prevent an exception escape on unusual classes.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
 
 tests_require =
     pytest
+    wrapt
 
     pandas>=0.24.2,<0.25; python_version=='2.7' and platform_python_implementation != 'PyPy'
     numpy>=1.16.3,<1.17; python_version=='2.7' and platform_python_implementation != 'PyPy'
@@ -48,6 +49,7 @@ tests_require =
 [options.extras_require]
 tests =
     pytest
+    wrapt
 
     pandas>=0.24.2,<0.25; python_version=='2.7' and platform_python_implementation != 'PyPy'
     numpy>=1.16.3,<1.17; python_version=='2.7' and platform_python_implementation != 'PyPy'

--- a/tests/test_cheap_repr.py
+++ b/tests/test_cheap_repr.py
@@ -231,9 +231,9 @@ class TestCheapRepr(TestCaseWithUtils):
         self.assert_cheap_repr(array('l', range(10)),
                                "array('l', [0, 1, 2, ..., 8, 9])")
 
-    def test_wrapt_objectproxy(self):
+    def test_uninitialized_class_with_getattr(self):
+        """An oversimplified wrapt.ObjectProxy style example."""
 
-        # No need to import wrapt, we recreate a tiny similar scenario.
         class DemonstrateBug(object):
             """
             This class mirrors what effectively happens with wrapt.ObjectProxy
@@ -260,6 +260,13 @@ class TestCheapRepr(TestCaseWithUtils):
                 return getattr(self._special, name)
 
         DemonstrateBug()
+
+    def test_wrapt_objectproxy(self):
+        import wrapt
+        class Uhoh(wrapt.ObjectProxy):
+            def __init__(self):
+                cheap_repr(self)
+        Uhoh()
 
     def test_django_queryset(self):
         os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.fake_django_settings'


### PR DESCRIPTION
`cheap_repr()` is called by `snoop` on lines of code where class instances
that define their own dunder methods like `__getattr__` may be in an
inconsistent state and thus raise an unusual exception.

`wrapt.ObjectProxy` is one such example.  It is used by `astroid`.  So
if you try and `snoop` the execution of part of `pylint`, it blows up
due to snoop without this patch.

This could be caught and handled in `snoop` itself, but it _seems_ like
the point of `cheap_repr` is to be safe from exceptions?